### PR TITLE
chore: require resources and lab time limits

### DIFF
--- a/container-service/main.hcl
+++ b/container-service/main.hcl
@@ -3,8 +3,13 @@ resource "lab" "container_service" {
   description = "This is an example lab with a single container sandbox and a service tab to display a web page hosted by the container."
 
   settings {
+    timelimit {
+      duration = "1h"
+    }
+
     idle {
       enabled = false
+      timeout = "15m"
     }
   }
 

--- a/container-service/sandbox.hcl
+++ b/container-service/sandbox.hcl
@@ -12,6 +12,11 @@ resource "container" "nginx" {
     host  = 80
   }
 
+  resources {
+    cpu    = 250
+    memory = 256
+  }
+
   network {
     id = resource.network.main.meta.id
   }

--- a/container-terminal/main.hcl
+++ b/container-terminal/main.hcl
@@ -3,8 +3,13 @@ resource "lab" "container_terminal" {
   description = "This is an example lab with a single container sandbox and a terminal tab."
 
   settings {
+    timelimit {
+      duration = "1h"
+    }
+
     idle {
       enabled = false
+      timeout = "15m"
     }
   }
 

--- a/container-terminal/sandbox.hcl
+++ b/container-terminal/sandbox.hcl
@@ -7,6 +7,11 @@ resource "container" "ubuntu" {
     name = "ubuntu"
   }
 
+  resources {
+    cpu    = 250
+    memory = 256
+  }
+
   network {
     id = resource.network.main.meta.id
   }

--- a/demo/main.hcl
+++ b/demo/main.hcl
@@ -3,10 +3,14 @@ resource "lab" "demo" {
   description = "This is a demo example lab."
 
   settings {
+    timelimit {
+      duration = "1h"
+    }
+
     idle {
       show_warning = true
       enabled = true
-      timeout = "2m"
+      timeout = "15m"
     }
   }
 

--- a/demo/sandbox.hcl
+++ b/demo/sandbox.hcl
@@ -18,7 +18,8 @@ resource "container" "workstation" {
   }
 
   resources {
-    memory = "512"
+    cpu    = 500
+    memory = 512
   }
 
   command = ["tail", "-f", "/dev/null"]

--- a/edb-pgd-multi-site-banking-demo/main.hcl
+++ b/edb-pgd-multi-site-banking-demo/main.hcl
@@ -3,8 +3,13 @@ resource "lab" "edb_pgd_multi_site_banking_demo" {
   description = "Live demo of EDB Postgres Distributed running a multi-site banking workload — zero-downtime maintenance, rolling upgrades, and elastic node operations across an Always On Gold topology (4 data + 1 witness)."
 
   settings {
+    timelimit {
+      duration = "1h"
+    }
+
     idle {
       enabled = false
+      timeout = "15m"
     }
   }
 

--- a/edb-pgd-multi-site-banking-demo/sandbox.hcl
+++ b/edb-pgd-multi-site-banking-demo/sandbox.hcl
@@ -9,6 +9,11 @@ resource "container" "workstation" {
 
   command = ["sleep", "infinity"]
 
+  resources {
+    cpu    = 500
+    memory = 512
+  }
+
   network {
     id = resource.network.main.meta.id
   }

--- a/experimental/main.hcl
+++ b/experimental/main.hcl
@@ -3,8 +3,13 @@ resource "lab" "experimental" {
   description = "This is an experimental example lab."
 
   settings {
+    timelimit {
+      duration = "1h"
+    }
+
     idle {
       enabled = false
+      timeout = "15m"
     }
   }
 

--- a/google-project/google.hcl
+++ b/google-project/google.hcl
@@ -66,6 +66,11 @@ resource "container" "google_cloud_cli" {
     source = resource.template.google_cloud_key.destination
     destination = "/home/cloudsdk/key.json"
   }
+
+  resources {
+    cpu    = 500
+    memory = 512
+  }
 }
 
 resource "exec" "generate_ssh_key" {

--- a/google-project/main.hcl
+++ b/google-project/main.hcl
@@ -3,8 +3,13 @@ resource "lab" "google_project" {
   description = "How to chain cloud accounts and other resources together"
 
   settings {
+    timelimit {
+      duration = "1h"
+    }
+
     idle {
       enabled = false
+      timeout = "15m"
     }
   }
 

--- a/in-use-assets/main.hcl
+++ b/in-use-assets/main.hcl
@@ -1,6 +1,17 @@
 resource "lab" "in-use-assets" {
   title       = "In Use Assets"
   description = "Check our [read-me](./assets/README.md) manifest *alstublieft*"
+
+  settings {
+    timelimit {
+      duration = "1h"
+    }
+
+    idle {
+      timeout = "15m"
+    }
+  }
+
   layout      = resource.layout.simple
 
   content {

--- a/k8s-terminal/main.hcl
+++ b/k8s-terminal/main.hcl
@@ -2,6 +2,16 @@ resource "lab" "k8s_single_node" {
   title       = "Single Node Kubernetes Cluster"
   description = "This is an example lab with a single node Kubernetes (k3s) cluster and a terminal tab."
 
+  settings {
+    timelimit {
+      duration = "1h"
+    }
+
+    idle {
+      timeout = "15m"
+    }
+  }
+
   layout = resource.layout.two_column
 
   content {

--- a/k8s-terminal/sandbox.hcl
+++ b/k8s-terminal/sandbox.hcl
@@ -7,6 +7,11 @@ resource "kubernetes_cluster" "k3s" {
   network {
     id = resource.network.main.meta.id
   }
+
+  resources {
+    cpu    = 2000
+    memory = 2048
+  }
 }
 
 // This container is used as an interactive terminal to the Kubernetes cluster.
@@ -20,6 +25,11 @@ resource "container" "workstation" {
   // Override the default entrypoint to use bash instead of kubectl,
   // so the container does not exit immediately.
   entrypoint = ["/bin/bash"]
+
+  resources {
+    cpu    = 250
+    memory = 256
+  }
 
   network {
     id = resource.network.main.meta.id

--- a/minimal/main.hcl
+++ b/minimal/main.hcl
@@ -7,8 +7,13 @@ resource "lab" "minimal" {
   description = "This is a minimal example lab."
 
   settings {
+    timelimit {
+      duration = "1h"
+    }
+
     idle {
       enabled = false
+      timeout = "15m"
     }
   }
 

--- a/minimal/sandbox.hcl
+++ b/minimal/sandbox.hcl
@@ -9,6 +9,11 @@ resource "container" "ubuntu" {
 
   command = ["tail", "-f", "/dev/null"]
 
+  resources {
+    cpu    = 250
+    memory = 256
+  }
+
 	network {
 		id = resource.network.main.meta.id
 	}

--- a/quiz/main.hcl
+++ b/quiz/main.hcl
@@ -3,8 +3,13 @@ resource "lab" "quiz" {
   description = "This is an example lab that shows how to add quizzes to your content."
 
   settings {
+    timelimit {
+      duration = "1h"
+    }
+
     idle {
       enabled = false
+      timeout = "15m"
     }
   }
 

--- a/skeleton/main.hcl
+++ b/skeleton/main.hcl
@@ -2,5 +2,15 @@ resource "lab" "main" {
   title       = "Skeleton Lab"
   description = "This is the Skeleton Lab.\nYou can use this as a minimal starting point for developing labs.\n\nFor more information, check ./assets/README.md"
 
+  settings {
+    timelimit {
+      duration = "1h"
+    }
+
+    idle {
+      timeout = "15m"
+    }
+  }
+
   layout = resource.layout.single_panel
 }

--- a/task/main.hcl
+++ b/task/main.hcl
@@ -3,8 +3,13 @@ resource "lab" "task" {
   description = "This is an example lab that shows how to add tasks to your content."
 
   settings {
+    timelimit {
+      duration = "1h"
+    }
+
     idle {
       enabled = false
+      timeout = "15m"
     }
   }
 

--- a/task/sandbox.hcl
+++ b/task/sandbox.hcl
@@ -2,4 +2,9 @@ resource "container" "ubuntu" {
   image {
     name = "ubuntu"
   }
+
+  resources {
+    cpu    = 250
+    memory = 256
+  }
 }

--- a/vm-task-service-test/main.hcl
+++ b/vm-task-service-test/main.hcl
@@ -3,8 +3,13 @@ resource "lab" "vm_task_service_test" {
   description = "Throwaway scratch lab to verify that task conditions and service tabs can target a vm resource directly, and that exec output can flow into page variables — the pattern the coder-agents-ai-governance V1 track migration depends on."
 
   settings {
+    timelimit {
+      duration = "1h"
+    }
+
     idle {
       enabled = false
+      timeout = "15m"
     }
   }
 


### PR DESCRIPTION
## Summary
Updates every example lab to satisfy the new mandatory schema rules from
instruqt/mono#792 (`resources` cpu/memory and lab `timelimit`/`idle` are now required).

## What Changed
- **Time settings** (13 labs): every `lab` now has `settings { timelimit { duration } idle { timeout } }`. Ten labs had `idle { enabled = false }` with no timeout (now invalid) and gained `timeout = "15m"`; `k8s-terminal`, `in-use-assets`, and `skeleton` had no `settings` block and got a full one. Durations are 1h, idle timeout 15m across the board.
- **Resources**: added `resources { cpu, memory }` to every container, vm, and kubernetes_cluster that lacked one (nginx, ubuntu terminals, workstations, gcloud CLI, k3s cluster).
- **demo**: its container had `resources { memory = "512" }` with no cpu and a string value — fixed to `cpu = 500, memory = 512`.

## Why
mono#792 enforces these at schema/transform time to prevent unbounded resources
and sessions that never stop. The existing examples omitted them and would now
fail validation. Kept sizing lean (250m/256MB for lightweight containers,
2000m/2048MB for the k3s cluster).

## Related
Refs instruqt/mono#792