### PR TITLE
fix: set idle.enabled explicitly on example labs

### DIFF
--- a/container-service/main.hcl
+++ b/container-service/main.hcl
@@ -8,7 +8,7 @@ resource "lab" "container_service" {
     }
 
     idle {
-      enabled = false
+      enabled = true
       timeout = "15m"
     }
   }

--- a/container-terminal/main.hcl
+++ b/container-terminal/main.hcl
@@ -8,7 +8,7 @@ resource "lab" "container_terminal" {
     }
 
     idle {
-      enabled = false
+      enabled = true
       timeout = "15m"
     }
   }

--- a/edb-pgd-multi-site-banking-demo/main.hcl
+++ b/edb-pgd-multi-site-banking-demo/main.hcl
@@ -8,7 +8,7 @@ resource "lab" "edb_pgd_multi_site_banking_demo" {
     }
 
     idle {
-      enabled = false
+      enabled = true
       timeout = "15m"
     }
   }

--- a/experimental/main.hcl
+++ b/experimental/main.hcl
@@ -8,7 +8,7 @@ resource "lab" "experimental" {
     }
 
     idle {
-      enabled = false
+      enabled = true
       timeout = "15m"
     }
   }

--- a/google-project/main.hcl
+++ b/google-project/main.hcl
@@ -8,7 +8,7 @@ resource "lab" "google_project" {
     }
 
     idle {
-      enabled = false
+      enabled = true
       timeout = "15m"
     }
   }

--- a/in-use-assets/main.hcl
+++ b/in-use-assets/main.hcl
@@ -8,6 +8,7 @@ resource "lab" "in-use-assets" {
     }
 
     idle {
+      enabled = true
       timeout = "15m"
     }
   }

--- a/k8s-terminal/main.hcl
+++ b/k8s-terminal/main.hcl
@@ -8,6 +8,7 @@ resource "lab" "k8s_single_node" {
     }
 
     idle {
+      enabled = true
       timeout = "15m"
     }
   }

--- a/minimal/main.hcl
+++ b/minimal/main.hcl
@@ -12,7 +12,7 @@ resource "lab" "minimal" {
     }
 
     idle {
-      enabled = false
+      enabled = true
       timeout = "15m"
     }
   }

--- a/quiz/main.hcl
+++ b/quiz/main.hcl
@@ -8,7 +8,7 @@ resource "lab" "quiz" {
     }
 
     idle {
-      enabled = false
+      enabled = true
       timeout = "15m"
     }
   }

--- a/skeleton/main.hcl
+++ b/skeleton/main.hcl
@@ -8,6 +8,7 @@ resource "lab" "main" {
     }
 
     idle {
+      enabled = true
       timeout = "15m"
     }
   }

--- a/task/main.hcl
+++ b/task/main.hcl
@@ -8,7 +8,7 @@ resource "lab" "task" {
     }
 
     idle {
-      enabled = false
+      enabled = true
       timeout = "15m"
     }
   }

--- a/vm-task-service-test/main.hcl
+++ b/vm-task-service-test/main.hcl
@@ -8,7 +8,7 @@ resource "lab" "vm_task_service_test" {
     }
 
     idle {
-      enabled = false
+      enabled = true
       timeout = "15m"
     }
   }


### PR DESCRIPTION
## Summary
Sets `idle.enabled = true` explicitly on every example lab. The 15m idle
timeout added in #23 is only enforced when `idle.enabled` is true, and the
schema's `default: true` is not injected at transform time — so an omitted or
`false` value leaves the timeout inert.

## What Changed
- Flipped `idle.enabled` from `false` to `true` in 9 labs (container-service,
  container-terminal, task, quiz, experimental, google-project,
  vm-task-service-test, edb-pgd-multi-site-banking-demo, minimal).
- Added an explicit `enabled = true` to 3 labs that omitted it (k8s-terminal,
  in-use-assets, skeleton). demo already had it.

## Why
The lab converter only sets `Settings.Idle.Enabled` when the field is present
in HCL; otherwise it's left unset rather than defaulted to true. Being explicit
guarantees idle reclaiming actually runs, which is the point of the required
timeout (cost control).

## Related
Refs instruqt/mono#792, instruqt/lab-examples#23